### PR TITLE
fix: correct resource type ordering and type handling in sync script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "description": "Roadmap content for roadmap.sh",
   "scripts": {
     "format": "prettier --write .",
+    "typecheck": "tsc --noEmit",
     "sync:content-to-repo": "tsx ./scripts/sync-content-to-repo.ts",
     "sync:repo-to-database": "tsx ./scripts/sync-repo-to-database.ts",
     "cleanup:orphaned-content": "tsx ./scripts/cleanup-orphaned-content.ts"

--- a/scripts/sync-repo-to-database.ts
+++ b/scripts/sync-repo-to-database.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { OfficialRoadmapDocument } from './lib/official-roadmap';
-import { parse } from 'node-html-parser';
+import { parse, type HTMLElement } from 'node-html-parser';
 import { markdownToHtml } from './lib/markdown';
 import { htmlToMarkdown } from './lib/html';
 import {
@@ -174,7 +174,6 @@ try {
       );
 
       if (listWithJustLinks.length > 0) {
-        // @ts-expect-error - TODO: fix this
         ulWithLinks = ul;
       }
     });
@@ -187,9 +186,9 @@ try {
               let linkText = link.textContent || '';
               const linkHref = link.getAttribute('href') || '';
               let linkType = linkText.match(typePattern)?.[1] || 'article';
-              linkType = allowedOfficialRoadmapTopicResourceType.includes(
-                linkType as any,
-              )
+              linkType = (
+                allowedOfficialRoadmapTopicResourceType as readonly string[]
+              ).includes(linkType)
                 ? linkType
                 : 'article';
 
@@ -201,16 +200,11 @@ try {
                 type: linkType as AllowedOfficialRoadmapTopicResourceType,
               };
             })
-            .sort((a, b) => {
-              const order = [
-                'official',
-                'opensource',
-                'article',
-                'video',
-                'feed',
-              ];
-              return order.indexOf(a.type) - order.indexOf(b.type);
-            })
+            .sort(
+              (a, b) =>
+                allowedOfficialRoadmapTopicResourceType.indexOf(a.type) -
+                allowedOfficialRoadmapTopicResourceType.indexOf(b.type),
+            )
         : [];
 
     const title = rootHtml.querySelector('h1');


### PR DESCRIPTION
## What

Fixes two issues in `scripts/sync-repo-to-database.ts` and wires up type checking so they cannot regress:

1. **Resource type ordering bug** — the `sort()` only knew about `official`, `opensource`, `article`, `video` and `feed`. Resources of type `course`, `podcast`, `book` and `roadmap` got `indexOf` -1 and were therefore sorted *before* everything else, breaking the order documented in `contributing.md`. The sort order is now derived from `allowedOfficialRoadmapTopicResourceType`, the single source of truth.

2. **Suppressed type error (TODO)** — the `@ts-expect-error - TODO: fix this` at line 177 was masking a real `TS2740`: `HTMLElement` resolved to the DOM lib type while `querySelectorAll('ul')` returns `node-html-parser`'s `HTMLElement` (274+ properties missing). Fixed by importing the type from `node-html-parser`; the directive is removed. Also removed an `as any` cast in the same block.

3. **No typecheck script existed** — the sync tooling was never typechecked (tsx skips it), which is why the suppressed error went unnoticed. Added `npm run typecheck` (`tsc --noEmit`).

## Verification

- `npx tsc --noEmit` passes cleanly with the directive removed.
- Functional check with the real parsing pipeline (`node-html-parser` + `markdown-it`): before, `course, book, podcast, roadmap` links landed first; after, output follows the canonical order `roadmap, official, opensource, article, course, podcast, video, book, feed`.
- `prettier --check` passes.
