### PR TITLE
chore: add topic descriptions for orphaned topics

### DIFF
--- a/roadmaps/aspnet-core/content/bogus@QERTjawqCCCkHfR44Ca0s.md
+++ b/roadmaps/aspnet-core/content/bogus@QERTjawqCCCkHfR44Ca0s.md
@@ -1,1 +1,3 @@
 # Bogus
+
+Bogus is a simple, C#-friendly fake data generator. It lets you create realistic mock objects, lists, and data sets with a fluent API, making it easy to seed tests and demo applications with believable data.

--- a/roadmaps/aspnet-core/content/distributed-lock@T2FsSndxzSuKTFdjoyPi-.md
+++ b/roadmaps/aspnet-core/content/distributed-lock@T2FsSndxzSuKTFdjoyPi-.md
@@ -1,1 +1,3 @@
 # Distributed Lock
+
+A distributed lock coordinates access to a shared resource across multiple processes or services. It prevents concurrent modifications and race conditions by ensuring only one client holds the lock at a time, typically backed by a store such as Redis, ZooKeeper, or a database.

--- a/roadmaps/aspnet-core/content/frameworks@1YL7aXluINOO15W3waaiD.md
+++ b/roadmaps/aspnet-core/content/frameworks@1YL7aXluINOO15W3waaiD.md
@@ -1,1 +1,3 @@
 # Frameworks
+
+.NET offers a range of frameworks built on the base runtime, each addressing a specific domain: ASP.NET Core for web applications and APIs, EF Core for data access, and .NET MAUI for cross-platform client apps. Choosing the right framework for the job is one of the first decisions when starting a new .NET project.

--- a/roadmaps/aspnet-core/content/gitlab-cicd@8Y73Ae32eo6_ye7dw5QRQ.md
+++ b/roadmaps/aspnet-core/content/gitlab-cicd@8Y73Ae32eo6_ye7dw5QRQ.md
@@ -1,1 +1,3 @@
 # GitLab CI/CD
+
+GitLab CI/CD is the continuous integration and delivery tooling built into GitLab. Pipelines are defined in a `.gitlab-ci.yml` file, where jobs run on GitLab runners to build, test, and deploy your application automatically on every change.

--- a/roadmaps/aspnet-core/content/mapperly@x0OopRTwIvoWgT8qi0CE9.md
+++ b/roadmaps/aspnet-core/content/mapperly@x0OopRTwIvoWgT8qi0CE9.md
@@ -1,1 +1,3 @@
 # Mapperly
+
+Mapperly is a source generator for .NET that maps objects without runtime reflection. It generates the mapping code at compile time, making it fast and keeping mappings in sync with your models — just declare a mapper class and it takes care of the rest.

--- a/roadmaps/aspnet-core/content/marten@ipb6proIZKG-_vCOMAiBu.md
+++ b/roadmaps/aspnet-core/content/marten@ipb6proIZKG-_vCOMAiBu.md
@@ -1,1 +1,3 @@
 # Marten
+
+Marten is a .NET document database library built on PostgreSQL. It turns PostgreSQL into a document store, letting you persist and query .NET objects as JSON documents while still leveraging SQL features such as indexes, transactions, and native Postgres tooling.

--- a/roadmaps/aspnet-core/content/net-aspire@HqhqqiA5X00Xl1RnZgrNJ.md
+++ b/roadmaps/aspnet-core/content/net-aspire@HqhqqiA5X00Xl1RnZgrNJ.md
@@ -1,1 +1,3 @@
 # .NET Aspire
+
+.NET Aspire is an opinionated stack for building observable, production-ready cloud-native .NET applications. It provides curated packages for common cloud dependencies, service discovery, orchestration for local development, and built-in telemetry to make distributed applications easier to build and debug.

--- a/roadmaps/aspnet-core/content/net-aspire@Ohc0xzI6qX4hOFVNfRj1F.md
+++ b/roadmaps/aspnet-core/content/net-aspire@Ohc0xzI6qX4hOFVNfRj1F.md
@@ -1,1 +1,3 @@
 # .NET Aspire
+
+.NET Aspire is an opinionated stack for building observable, production-ready cloud-native .NET applications. It provides curated packages for common cloud dependencies, service discovery, orchestration for local development, and built-in telemetry to make distributed applications easier to build and debug.

--- a/roadmaps/aspnet-core/content/net-maui@olqSPUU3RoxhQ6exfMzeN.md
+++ b/roadmaps/aspnet-core/content/net-maui@olqSPUU3RoxhQ6exfMzeN.md
@@ -1,1 +1,3 @@
 # .NET MAUI
+
+.NET MAUI (Multi-platform App UI) is the cross-platform UI framework for .NET. It lets you build native Android, iOS, macOS, and Windows applications from a single C# and XAML codebase, sharing business logic while still allowing per-platform customizations when needed.

--- a/roadmaps/aspnet-core/content/respawn@TCswZHviRiu6SIOwUisu8.md
+++ b/roadmaps/aspnet-core/content/respawn@TCswZHviRiu6SIOwUisu8.md
@@ -1,1 +1,3 @@
 # Respawn
+
+Respawn is a small .NET utility for resetting test databases to a clean state. It intelligently deletes data by tracking dependencies between tables, so you can run integration tests quickly without manually managing cleanup between test runs.

--- a/roadmaps/aspnet-core/content/scalar@Zb4Gugxf7d6MoeEcfngrV.md
+++ b/roadmaps/aspnet-core/content/scalar@Zb4Gugxf7d6MoeEcfngrV.md
@@ -1,1 +1,3 @@
 # Scalar
+
+Scalar is a lightweight API platform for .NET that generates interactive API documentation and a UI for testing endpoints. It integrates with ASP.NET Core as a fast, configurable alternative to the default Swagger UI, built on the OpenAPI specification.

--- a/roadmaps/aspnet-core/content/test-containers@8eW5BaOjJbnQ7uk4zMOiU.md
+++ b/roadmaps/aspnet-core/content/test-containers@8eW5BaOjJbnQ7uk4zMOiU.md
@@ -1,1 +1,3 @@
 # Test Containers
+
+Testcontainers is a library that runs throwaway Docker containers for your tests. The .NET version lets you spin up real instances of databases, message brokers, and other services inside integration tests, then disposes of them automatically when the tests finish.

--- a/roadmaps/blockchain/content/tvm-based@miBEG3x_foKYxwfX4Tr4f.md
+++ b/roadmaps/blockchain/content/tvm-based@miBEG3x_foKYxwfX4Tr4f.md
@@ -1,1 +1,3 @@
 # TVM-Based
+
+TVM-based blockchains execute smart contracts on a stack-based virtual machine rather than the Ethereum Virtual Machine. The most prominent example is the TON blockchain, whose Telegram Virtual Machine (TVM) uses its own bytecode and design, trading Ethereum-tooling compatibility for performance and unique contract capabilities.

--- a/roadmaps/datastructures-and-algorithms/content/a-algorithm@AabJqPUwFVBVS02YPDPvL.md
+++ b/roadmaps/datastructures-and-algorithms/content/a-algorithm@AabJqPUwFVBVS02YPDPvL.md
@@ -1,1 +1,3 @@
 # A* Algorithm
+
+A* is a pathfinding and graph traversal algorithm that finds the shortest path between two nodes. It combines the guarantees of Dijkstra's algorithm with a heuristic that estimates the remaining distance, guiding the search toward the goal and exploring far fewer nodes in practice.

--- a/roadmaps/datastructures-and-algorithms/content/cyclic-sort@L1FIJAluyxG6CGaVLM20O.md
+++ b/roadmaps/datastructures-and-algorithms/content/cyclic-sort@L1FIJAluyxG6CGaVLM20O.md
@@ -1,1 +1,3 @@
 # Cyclic Sort
+
+Cyclic sort is a sorting technique for arrays whose values fall in a known, contiguous range, typically `1` to `n`. Each element is swapped to the position matching its value, placing everything correctly in O(n) time and O(1) space — ideal as a building block for problems such as finding missing or duplicate numbers.

--- a/roadmaps/datastructures-and-algorithms/content/fast-and-slow-pointers@J_No8GTa92DcwPtua30wL.md
+++ b/roadmaps/datastructures-and-algorithms/content/fast-and-slow-pointers@J_No8GTa92DcwPtua30wL.md
@@ -1,1 +1,3 @@
 # Fast and Slow Pointers
+
+The fast and slow pointers pattern uses two pointers that traverse a data structure at different speeds. It is commonly used to detect cycles in linked lists, find the middle of a list, or locate the kth element from the end, running in O(n) time with constant space.

--- a/roadmaps/datastructures-and-algorithms/content/island-traversal@q9qLI6HzOJ0vYaIVrZ5CU.md
+++ b/roadmaps/datastructures-and-algorithms/content/island-traversal@q9qLI6HzOJ0vYaIVrZ5CU.md
@@ -1,1 +1,3 @@
 # Island traversal
+
+Island traversal is a grid-based technique used to find connected regions of cells that share a common value, typically `1`s in a binary matrix. It combines grid traversal with depth-first or breadth-first search — often with visited tracking — to count islands, measure their size, or analyze their shape.

--- a/roadmaps/datastructures-and-algorithms/content/kth-element@JcchUF_U99zkFpXp3VT2R.md
+++ b/roadmaps/datastructures-and-algorithms/content/kth-element@JcchUF_U99zkFpXp3VT2R.md
@@ -1,1 +1,3 @@
 # Kth Element
+
+Kth element problems ask you to find the kth smallest (or largest) element in a collection without fully sorting it. Common solutions include heaps, quickselect, or sorting, depending on the constraints — a pattern that also appears in questions about arrays, streams, and binary search trees.

--- a/roadmaps/datastructures-and-algorithms/content/merge-intervals@S2mBvlFTd673XcXxisD5P.md
+++ b/roadmaps/datastructures-and-algorithms/content/merge-intervals@S2mBvlFTd673XcXxisD5P.md
@@ -1,1 +1,3 @@
 # Merge Intervals
+
+The merge intervals pattern deals with overlapping ranges, typically merging a list of intervals that intersect. The standard approach sorts the intervals by start time and then folds them together in a single pass — a technique used in scheduling, availability, and range problems.

--- a/roadmaps/datastructures-and-algorithms/content/multi-threaded@gaaRAL3HR48Qj9rz1CkDU.md
+++ b/roadmaps/datastructures-and-algorithms/content/multi-threaded@gaaRAL3HR48Qj9rz1CkDU.md
@@ -1,1 +1,3 @@
 # Multi-threaded
+
+Multi-threaded algorithms divide work across multiple threads to run faster on multi-core machines. Common patterns include parallel divide-and-conquer, thread-safe queues for producer-consumer flows, and careful synchronization to avoid race conditions — with quality often measured by speedup and scalability.

--- a/roadmaps/devrel/content/video-production@bRzzc137OlmivEGdhv5Ew.md
+++ b/roadmaps/devrel/content/video-production@bRzzc137OlmivEGdhv5Ew.md
@@ -1,1 +1,3 @@
 # Video Production
+
+Video production for developer relations covers planning, recording, and publishing technical content such as tutorials, live streams, and conference talks. It involves scripting, screen and audio capture, editing, and distribution — with emphasis on clear code visuals and practical examples for a developer audience.

--- a/roadmaps/flutter/content/appstore@JHkdIQRgf1bbL-HASvGi0.md
+++ b/roadmaps/flutter/content/appstore@JHkdIQRgf1bbL-HASvGi0.md
@@ -1,1 +1,3 @@
 # AppStore
+
+The App Store is Apple's platform for distributing iOS and iPadOS applications. Publishing a Flutter app there requires an Apple Developer account, app metadata, signing with certificates and provisioning profiles, and submitting the build for App Review before release.

--- a/roadmaps/flutter/content/firebase@EVd1rLBHjKbtgkIE7InS7.md
+++ b/roadmaps/flutter/content/firebase@EVd1rLBHjKbtgkIE7InS7.md
@@ -1,1 +1,3 @@
 # Firebase
+
+Firebase is Google's mobile development platform that provides backend services like authentication, the Cloud Firestore database, cloud storage, and push notifications. The FlutterFire plugins integrate these services into Flutter apps, letting you add a backend without running your own servers.

--- a/roadmaps/power-bi/content/hierarchies@teGp4rdsa8O-Au8mHbrkH.md
+++ b/roadmaps/power-bi/content/hierarchies@teGp4rdsa8O-Au8mHbrkH.md
@@ -1,0 +1,3 @@
+# Hierarchies
+
+Hierarchies in Power BI let you navigate data across multiple levels of detail, such as year to quarter to month to day. Built from related columns or tables, they enable drill-up and drill-down in reports and can be defined in the data model or directly in Power Query.

--- a/roadmaps/react-native/content/listings@x-OZCZcX6uhN3Yr5BAATn.md
+++ b/roadmaps/react-native/content/listings@x-OZCZcX6uhN3Yr5BAATn.md
@@ -1,1 +1,3 @@
 # Listings
+
+Listings in React Native — primarily `FlatList` and `SectionList` — are the core components for rendering scrollable lists. They are optimized for large data sets with lazy row rendering, pull-to-refresh, header and footer support, and per-row memoization for better performance.

--- a/roadmaps/react-native/content/listviews@h3ypxGxeHDCTxURHg6D2d.md
+++ b/roadmaps/react-native/content/listviews@h3ypxGxeHDCTxURHg6D2d.md
@@ -1,1 +1,3 @@
 # ListViews
+
+`ListView` was the original list component in React Native, now superseded by the more efficient `FlatList` and `SectionList`. These components render data in a performant, scrollable way by only mounting rows near the viewport, and support features like separators, empty states, and pull-to-refresh.

--- a/roadmaps/react-native/content/view@GrFL32pZ_eOmdJRzSlH8b.md
+++ b/roadmaps/react-native/content/view@GrFL32pZ_eOmdJRzSlH8b.md
@@ -1,1 +1,3 @@
 # View
+
+`View` is the fundamental layout container in React Native, similar to a `div` in web development. It supports flexbox layout, styling, touch handling, and nesting, and is the building block for nearly every screen and component.

--- a/roadmaps/react/content/usestate@YEpkbNzEMzS6wAKg85J_N.md
+++ b/roadmaps/react/content/usestate@YEpkbNzEMzS6wAKg85J_N.md
@@ -1,1 +1,3 @@
 # useState
+
+`useState` is a React Hook that adds state to function components. It returns an array with the current state value and a setter function; calling the setter with a new value schedules a re-render, and you can pass a function to compute the new state from the previous one.

--- a/roadmaps/software-design-architecture/content/architectural-patterns@gJYff_qD6XS3dg3I-jJFK.md
+++ b/roadmaps/software-design-architecture/content/architectural-patterns@gJYff_qD6XS3dg3I-jJFK.md
@@ -1,1 +1,3 @@
 # Architectural Patterns
+
+Architectural patterns are high-level structural templates that shape the overall organization of a system, such as layered architecture, microservices, event-driven, and serverless. They define how major components communicate and scale, and are chosen based on the problem domain, team, and operational requirements.

--- a/roadmaps/software-design-architecture/content/architectural-principles@dBq7ni-of5v1kxpdmh227.md
+++ b/roadmaps/software-design-architecture/content/architectural-principles@dBq7ni-of5v1kxpdmh227.md
@@ -1,1 +1,3 @@
 # Architectural Principles
+
+Architectural principles are fundamental rules that guide design decisions across a system, such as loose coupling, high cohesion, separation of concerns, and scalability. They are the "why" behind a structure, helping teams make consistent trade-offs and evolve software without reworking its foundations.

--- a/roadmaps/software-design-architecture/content/design-principles@9dMbo4Q1_Sd9wW6-HSCA9.md
+++ b/roadmaps/software-design-architecture/content/design-principles@9dMbo4Q1_Sd9wW6-HSCA9.md
@@ -1,1 +1,3 @@
 # Design Principles
+
+Design principles are guidelines for writing clean, maintainable code — with SOLID, DRY, YAGNI, and composition over inheritance among the most well-known. Applied at the module and class level, they reduce coupling, improve readability, and make the codebase easier to extend and test.

--- a/roadmaps/spring-boot/content/micrometer@GsmBGRohWbJ6XOaALFZ8o.md
+++ b/roadmaps/spring-boot/content/micrometer@GsmBGRohWbJ6XOaALFZ8o.md
@@ -1,1 +1,3 @@
 # Micrometer
+
+Micrometer is a vendor-neutral metrics facade for Java and the default metrics library in Spring Boot. It exposes application metrics — timers, gauges, counters, and histograms — through a unified API that can report to backends such as Prometheus, Datadog, or Graphite, and integrates with Spring Boot Actuator.


### PR DESCRIPTION
## What

Adds a concise, single-paragraph description to **32 topics** that only had a title and no content, following the [contributing guidelines](https://github.com/nilbuild/developer-roadmap/blob/master/contributing.md#adding-content) (English, one paragraph, no resource changes).

The affected topics were identified as empty (0 characters of description) across 10 roadmaps:

| Roadmap | Topics |
|---|---|
| `aspnet-core` | Bogus, Distributed Lock, Frameworks, GitLab CI/CD, Mapperly, Marten, .NET Aspire (x2), .NET MAUI, Respawn, Scalar, Testcontainers |
| `datastructures-and-algorithms` | A* Algorithm, Cyclic Sort, Fast and Slow Pointers, Island traversal, Kth Element, Merge Intervals, Multi-threaded |
| `software-design-architecture` | Architectural Patterns, Architectural Principles, Design Principles |
| `react-native` | Listings, ListViews, View |
| `flutter` | AppStore, Firebase |
| `blockchain` | TVM-Based |
| `devrel` | Video Production |
| `power-bi` | Hierarchies |
| `react` | useState |
| `spring-boot` | Micrometer |

Notes:

- `power-bi/hierarchies` had no content at all, not even a title — added the missing `# Hierarchies` heading as well.
- Resource links were intentionally left untouched; this PR only adds descriptions.

## Verification

- All 32 files pass the content validation script (`npm run validate:content -- --files=...`, exit 0).
- `prettier --check` passes.
