### PR TITLE
docs(terraform): explain HCL

### DIFF
--- a/roadmaps/terraform/content/what-is-hcl@Hma2IgatFME8STHPwpeMG.md
+++ b/roadmaps/terraform/content/what-is-hcl@Hma2IgatFME8STHPwpeMG.md
@@ -1,5 +1,7 @@
 # What is HCL?
 
+HCL (HashiCorp Configuration Language) is a structured configuration language designed to be easy for people to read and write. Terraform uses HCL in `.tf` files to describe infrastructure through blocks, arguments, and expressions. Terraform configurations are declarative: they describe the desired infrastructure state rather than a sequence of commands to create it.
+
 Visit the following resources to learn more:
 
 - [@official@Syntax - Configuration Language | Terraform](https://developer.hashicorp.com/terraform/language/syntax/configuration)


### PR DESCRIPTION
## What changed

- Add a concise introduction to HCL on the Terraform roadmap topic page.
- Explain how Terraform uses `.tf` files, blocks, arguments, and expressions.
- Clarify that Terraform configurations describe desired state declaratively.

## Why

The topic page previously linked to external resources without first defining HCL. This gives learners enough context to understand the concept before following those resources.

## Impact

Terraform learners get a short, plain-language explanation directly in the roadmap.

## Validation

- `git diff HEAD^ HEAD --check`
- Documentation-only change; no automated tests were required.
