### PR TITLE
Add Valibot resource links

### DIFF
--- a/roadmaps/react/content/zod@K3RZ8ESxWCpLKHePF87Hy.md
+++ b/roadmaps/react/content/zod@K3RZ8ESxWCpLKHePF87Hy.md
@@ -7,4 +7,5 @@ Zod is designed to be as developer-friendly as possible. The goal is to eliminat
 Visit the following resources to learn more:
 
 - [@official@Zod Website](https://zod.dev/)
+- [@official@Valibot - Alternative to Zod](https://valibot.dev/)
 - [@video@Learn Zod In 30 Minutes](https://www.youtube.com/watch?v=L6BE-U3oy80)

--- a/roadmaps/typescript/content/useful-packages@PCX3KcvMUW3mmQEepLTXp.md
+++ b/roadmaps/typescript/content/useful-packages@PCX3KcvMUW3mmQEepLTXp.md
@@ -5,6 +5,7 @@ TypeScript has a large ecosystem of packages that can be used to extend the lang
 Visit the following resources to learn more:
 
 - [@official@zod](https://zod.dev/)
+- [@official@valibot](https://valibot.dev/)
 - [@official@ts-node](https://typestrong.org/ts-node)
 - [@opensource@ts-morph](https://github.com/dsherret/ts-morph)
 - [@opensource@ts-jest](https://github.com/kulshekhar/ts-jest)


### PR DESCRIPTION
Adds Valibot as an alternative resource link in the Zod content of the React roadmap and to the useful packages list of the TypeScript roadmap. Valibot is a popular schema library with the same use cases as Zod. I'm the author of the library.