### PR TITLE
content: add UIZZE anti-ui-slop Skill to Claude Code roadmap

### DIFF
--- a/roadmaps/claude-code/content/skills@OJIfG7DRO4jgQEcberkNx.md
+++ b/roadmaps/claude-code/content/skills@OJIfG7DRO4jgQEcberkNx.md
@@ -8,5 +8,6 @@ Visit the following resources to learn more:
 - [@course@Introduction to agent skills](https://anthropic.skilljar.com/introduction-to-agent-skills)
 - [@official@Extend Claude with skills](https://code.claude.com/docs/en/skills#extend-claude-with-skills)
 - [@official@The Complete Guide to Building Skills for Claude](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf?hsLang=en)
+- [@opensource@UIZZE anti-ui-slop Skill](https://uizze.com/.well-known/agent-skills/anti-ui-slop/SKILL.md) — Free MIT Skill that grounds UI work in 800,000+ real web and iOS screens, requires a design contract and required states, and applies a pre-ship finish gate.
 - [@video@Claude Code Skills & skills.sh - Crash Course](https://www.youtube.com/watch?v=rcRS8-7OgBo)
 - [@video@MCP vs Skills: Which Is Right for Your AI Agent and LLMs?](https://www.youtube.com/watch?v=goU9VIXA8II)


### PR DESCRIPTION
## What this adds

- Adds the free MIT UIZZE anti-ui-slop Skill to the Claude Code Skills topic.
- Links to the live, domain-backed `SKILL.md` source.
- Describes the concrete workflow accurately: real web and iOS screen evidence, a design contract, required states, and a pre-ship finish gate.

This is one concise open-source resource link in an existing topic (now 7 links, within the eight-link limit). The live source returned HTTP 200 before submission.
