### PR TITLE
docs: improve ACID topic description and add MySQL documentation reso…

### DIFF
--- a/roadmaps/backend/content/acid@qSAdfaGUfn8mtmDjHJi3z.md
+++ b/roadmaps/backend/content/acid@qSAdfaGUfn8mtmDjHJi3z.md
@@ -1,10 +1,11 @@
 # ACID
 
-ACID represents four database transaction properties: Atomicity (all-or-nothing execution), Consistency (valid state maintenance), Isolation (concurrent transaction separation), and Durability (permanent commit survival). These principles ensure reliable data processing and integrity in database systems, crucial for financial and e-commerce applications.
+ACID stands for four key database transaction properties: Atomicity (all-or-nothing execution), Consistency (valid state maintenance), Isolation (concurrent transaction separation), and Durability (permanent commit survival). These principles ensure reliable data processing and integrity in database systems, which are crucial for financial and e-commerce applications.
 
 Visit the following resources to learn more:
 
-- [@book@Database System Concepts - Silberschatz, Korth, Sudarshan](https://db-book.com/)
 - [@official@PostgreSQL Tutorial on Transactions](https://www.postgresql.org/docs/current/tutorial-transactions.html)
-- [@article@What is ACID Compliant Database?](https://retool.com/blog/whats-an-acid-compliant-database/)
+- [@official@MySQL InnoDB and the ACID Model](https://dev.mysql.com/doc/refman/8.0/en/mysql-acid.html)
+- [@article@What is an ACID Compliant Database?](https://retool.com/blog/whats-an-acid-compliant-database/)
+- [@book@Database System Concepts - Silberschatz, Korth, Sudarshan](https://db-book.com/)
 - [@video@ACID Explained: Atomic, Consistent, Isolated & Durable](https://www.youtube.com/watch?v=yaQ5YMWkxq4)


### PR DESCRIPTION
## Summary of Changes
- Updated the **ACID** topic content under database roadmaps.
- Corrected article link grammar ("a ACID" -> "an ACID").
- Added the official **MySQL InnoDB ACID Model** documentation link to expand learning resources.

## Motivation
Provides clearer resource labels and adds essential documentation for developers learning about database transaction properties.

## Checklist
- [x] File name and node ID left intact (`acid@qSAdfaGUfn8mtmDjHJi3z.md`)
- [x] Link syntax tags (`@official@`, `@article@`, `@book@`) formatted correctly
- [x] Content verified for readability and accuracy