### PR TITLE
fix(cyber-security): replace 12 dead resource links

### DIFF
--- a/roadmaps/cyber-security/content/antimalware@9QtY1hMJ7NKLFztYK-mHY.md
+++ b/roadmaps/cyber-security/content/antimalware@9QtY1hMJ7NKLFztYK-mHY.md
@@ -5,5 +5,5 @@ Antimalware refers to software designed to detect, prevent, and remove malicious
 Visit the following resources to learn more:
 
 - [@article@Anti-malware Definition](https://www.computertechreviews.com/definition/anti-malware/)
-- [@article@What is Antimalware?](https://riskxchange.co/1006974/cybersecurity-what-is-anti-malware/)
+- [@article@Understanding Anti-Virus Software](https://www.cisa.gov/news-events/news/understanding-anti-virus-software)
 - [@video@How Does Antivirus and Antimalware Software Work?](https://www.youtube.com/watch?v=bTU1jbVXlmM)

--- a/roadmaps/cyber-security/content/cism@s86x24SHPEbbOB9lYNU-w.md
+++ b/roadmaps/cyber-security/content/cism@s86x24SHPEbbOB9lYNU-w.md
@@ -5,4 +5,4 @@ The Certified Information Security Manager (CISM) is an advanced cybersecurity c
 Visit the following resources to learn more:
 
 - [@official@CISM](https://www.isaca.org/credentialing/cism)
-- [@article@Certified Information Security Manager (CISM)](https://www.techtarget.com/searchsecurity/definition/certified-information-security-manager-CISM)
+- [@article@Certified Information Security Manager (CISM)](https://en.wikipedia.org/wiki/Certified_Information_Security_Manager)

--- a/roadmaps/cyber-security/content/common-protocols-and-their-uses@ViF-mpR17MB3_KJ1rV8mS.md
+++ b/roadmaps/cyber-security/content/common-protocols-and-their-uses@ViF-mpR17MB3_KJ1rV8mS.md
@@ -4,5 +4,5 @@ Networking protocols are standardized sets of rules that govern how data is tran
 
 Visit the following resources to learn more:
 
-- [@article@12 Common Network Protocols](https://www.techtarget.com/searchnetworking/feature/12-common-network-protocols-and-their-functions-explained)
+- [@article@What Is a Network Protocol?](https://www.comptia.org/en-us/blog/what-is-a-network-protocol/)
 - [@video@Networking For Hackers! (Common Network Protocols)](https://www.youtube.com/watch?v=p3vaaD9pn9I)

--- a/roadmaps/cyber-security/content/eap-vs-peap@1jwtExZzR9ABKvD_S9zFG.md
+++ b/roadmaps/cyber-security/content/eap-vs-peap@1jwtExZzR9ABKvD_S9zFG.md
@@ -5,4 +5,4 @@ EAP (Extensible Authentication Protocol) is an authentication framework providin
 Visit the following resources to learn more:
 
 - [@article@Extensible Authentication Protocol (EAP) for network access](https://learn.microsoft.com/en-us/windows-server/networking/technologies/extensible-authentication-protocol/network-access?tabs=eap-tls%2Cserveruserprompt-eap-tls%2Ceap-sim)
-- [@article@What is Protected Extensible Authentication Protocol (PEAP)](https://www.techtarget.com/searchsecurity/definition/PEAP-Protected-Extensible-Authentication-Protocol)
+- [@article@Protected Extensible Authentication Protocol (PEAP)](https://en.wikipedia.org/wiki/Protected_Extensible_Authentication_Protocol)

--- a/roadmaps/cyber-security/content/evil-twin@O1fY2n40yjZtJUEeoItKr.md
+++ b/roadmaps/cyber-security/content/evil-twin@O1fY2n40yjZtJUEeoItKr.md
@@ -4,5 +4,5 @@ An Evil Twin is a type of wireless network attack where an attacker sets up a ro
 
 Visit the following resources to learn more:
 
-- [@article@What is an Evil Twin attack?](https://www.techtarget.com/searchsecurity/definition/evil-twin)
+- [@article@Evil Twin (Wireless Networks)](https://en.wikipedia.org/wiki/Evil_twin_(wireless_networks))
 - [@video@How Hackers Can Grab Your Passwords Over Wi-Fi with Evil Twin Attacks](https://www.youtube.com/watch?v=HyxQqDq3qs4)

--- a/roadmaps/cyber-security/content/guestos@LocGETHz6ANYinNd5ZLsS.md
+++ b/roadmaps/cyber-security/content/guestos@LocGETHz6ANYinNd5ZLsS.md
@@ -4,5 +4,5 @@ A Guest Operating System (GuestOS) is an operating system installed within a vir
 
 Visit the following resources to learn more:
 
-- [@article@What is a Guest Operating System?](https://www.techtarget.com/searchitoperations/definition/guest-OS-guest-operating-system)
+- [@article@Guest Operating System - NIST Glossary](https://csrc.nist.gov/glossary/term/guest_operating_system)
 - [@article@Guest Operating System](https://nordvpn.com/cybersecurity/glossary/guest-operating-system/?srsltid=AfmBOop0L-VFCtuYvEBQgHy7dCIa3sfzNVa-Zn6l0SniAYDpftfOgH7N)

--- a/roadmaps/cyber-security/content/iso@oRssaVG-K-JwlL6TAHhXw.md
+++ b/roadmaps/cyber-security/content/iso@oRssaVG-K-JwlL6TAHhXw.md
@@ -5,4 +5,4 @@ The International Organization for Standardization (ISO) is an international sta
 Visit the following resources to learn more:
 
 - [@official@International Organization for Standardization](https://www.iso.org/home.html)
-- [@article@What is the ISO?](https://www.techtarget.com/searchdatacenter/definition/ISO#:~:text=ISO%20(International%20Organization%20for%20Standardization)%20is%20a%20worldwide,federation%20of%20national%20standards%20bodies.)
+- [@article@ISO/IEC 27001 - Information Security Management](https://en.wikipedia.org/wiki/ISO/IEC_27001)

--- a/roadmaps/cyber-security/content/phishing@7obusm5UtHwWMcMMEB3lt.md
+++ b/roadmaps/cyber-security/content/phishing@7obusm5UtHwWMcMMEB3lt.md
@@ -5,6 +5,6 @@ Phishing is a type of social engineering attack where malicious actors attempt t
 Visit the following resources to learn more:
 
 - [@article@How to Recognize and Avoid Phishing Scams](https://consumer.ftc.gov/articles/how-recognize-and-avoid-phishing-scams)
-- [@article@phishing - definition](https://www.techtarget.com/searchsecurity/definition/phishing)
+- [@article@Recognize and Report Phishing](https://www.cisa.gov/secure-our-world/recognize-and-report-phishing)
 - [@video@Protect yourself from phishing](https://support.microsoft.com/en-us/windows/protect-yourself-from-phishing-0c7ea947-ba98-3bd9-7184-430e1f860a44)
 - [@video@Phishing attacks are SCARY easy to do!! (let me show you!)](https://www.youtube.com/watch?v=u9dBGWVwMMA)

--- a/roadmaps/cyber-security/content/radius@tH3RLnJseqOzRIbZMklHD.md
+++ b/roadmaps/cyber-security/content/radius@tH3RLnJseqOzRIbZMklHD.md
@@ -4,5 +4,5 @@
 
 Visit the following resources to learn more:
 
-- [@official@RFC 2865 - Remote Authentication Dial In User Service (RADIUS)](https://datatracker.ietf.org/doc/html/rfc2865)
+- [@official@Remote Authentication Dial In User Service (RADIUS) - RFC 2865](https://datatracker.ietf.org/doc/html/rfc2865)
 - [@video@How RADIUS Authentication Works](https://www.youtube.com/watch?v=LLrb3em-_po)

--- a/roadmaps/cyber-security/content/radius@tH3RLnJseqOzRIbZMklHD.md
+++ b/roadmaps/cyber-security/content/radius@tH3RLnJseqOzRIbZMklHD.md
@@ -4,5 +4,5 @@
 
 Visit the following resources to learn more:
 
-- [@article@RADIUS (Remote Authentication Dial-In User Service)](https://www.techtarget.com/searchsecurity/definition/RADIUS)
+- [@official@RFC 2865 - Remote Authentication Dial In User Service (RADIUS)](https://datatracker.ietf.org/doc/html/rfc2865)
 - [@video@How RADIUS Authentication Works](https://www.youtube.com/watch?v=LLrb3em-_po)

--- a/roadmaps/cyber-security/content/rmf@fjEdufrZAfW4Rl6yDU8Hk.md
+++ b/roadmaps/cyber-security/content/rmf@fjEdufrZAfW4Rl6yDU8Hk.md
@@ -4,5 +4,5 @@ The Risk Management Framework (RMF) is a structured, comprehensive process for m
 
 Visit the following resources to learn more:
 
-- [@article@What is the Risk Management Framework?](https://www.techtarget.com/searchcio/definition/Risk-Management-Framework-RMF)
+- [@official@About the Risk Management Framework (RMF)](https://csrc.nist.gov/projects/risk-management/about-rmf)
 - [@video@RMF explained in 5 minutes](https://www.youtube.com/watch?v=X5yqPFp__rc)

--- a/roadmaps/cyber-security/content/salting@jqWhR6oTyX6yolUBv71VC.md
+++ b/roadmaps/cyber-security/content/salting@jqWhR6oTyX6yolUBv71VC.md
@@ -4,4 +4,5 @@ Salting is a crucial concept within the realm of cryptography. It is a technique
 
 Visit the following resources to learn more:
 
-- [@article@What is salting?](https://www.techtarget.com/searchsecurity/definition/salt)
+- [@article@OWASP Password Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html)
+- [@article@Salt (Cryptography)](https://en.wikipedia.org/wiki/Salt_(cryptography))

--- a/roadmaps/cyber-security/content/watering-hole-attack@dcvuKHq0nHgHLcLwtl4IJ.md
+++ b/roadmaps/cyber-security/content/watering-hole-attack@dcvuKHq0nHgHLcLwtl4IJ.md
@@ -4,5 +4,5 @@ Watering Hole Attack is a type of cyberattack where the attacker targets a speci
 
 Visit the following resources to learn more:
 
-- [@article@What is a Watering Hole Attack?](https://www.techtarget.com/searchsecurity/definition/watering-hole-attack)
+- [@article@Watering Hole Attack](https://en.wikipedia.org/wiki/Watering_hole_attack)
 - [@video@Watering Hole Attacks](https://www.youtube.com/watch?v=uBoVWqkfZjk)


### PR DESCRIPTION
Fixes the dead links reported in #10249 for the Cyber Security roadmap.

### What I found

I re-checked all 628 distinct URLs in `roadmaps/cyber-security/content` and followed every redirect to its final status. One correction to the report in #10249: most of the TechTarget links are listed there under **3xx**, but the `301` is only the first hop — TechTarget reorganised its sections and the redirect **targets themselves 404**:

```
https://www.techtarget.com/searchsecurity/definition/phishing
  301 -> https://www.techtarget.com/cybersecurity/definition/phishing
  404
```

So these are not links that merely need their redirect resolved; the content is gone and they need genuine replacements. `watering-hole-attack` is dead the same way and was not in the original report.

12 links are confirmed 404 by two independent HTTP clients (`requests` and `curl`):

| Topic | Dead link | Replacement |
| --- | --- | --- |
| `radius` | techtarget `/definition/RADIUS` | `@official@` [RFC 2865](https://datatracker.ietf.org/doc/html/rfc2865) |
| `rmf` | techtarget `/definition/Risk-Management-Framework-RMF` | `@official@` [NIST CSRC — About the RMF](https://csrc.nist.gov/projects/risk-management/about-rmf) |
| `guestos` | techtarget `/definition/guest-OS-guest-operating-system` | [NIST CSRC Glossary](https://csrc.nist.gov/glossary/term/guest_operating_system) |
| `salting` | techtarget `/definition/salt` | [OWASP Password Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html) + [Salt (cryptography)](https://en.wikipedia.org/wiki/Salt_(cryptography)) |
| `phishing` | techtarget `/definition/phishing` | [CISA — Recognize and Report Phishing](https://www.cisa.gov/secure-our-world/recognize-and-report-phishing) |
| `antimalware` | riskxchange.co | [CISA — Understanding Anti-Virus Software](https://www.cisa.gov/news-events/news/understanding-anti-virus-software) |
| `common-protocols-and-their-uses` | techtarget `/12-common-network-protocols...` | [CompTIA — What Is a Network Protocol?](https://www.comptia.org/en-us/blog/what-is-a-network-protocol/) |
| `iso` | techtarget `/definition/ISO` | [ISO/IEC 27001](https://en.wikipedia.org/wiki/ISO/IEC_27001) |
| `cism` | techtarget `/definition/certified-information-security-manager-CISM` | [CISM](https://en.wikipedia.org/wiki/Certified_Information_Security_Manager) |
| `eap-vs-peap` | techtarget `/definition/PEAP...` | [PEAP](https://en.wikipedia.org/wiki/Protected_Extensible_Authentication_Protocol) |
| `evil-twin` | techtarget `/definition/evil-twin` | [Evil twin (wireless networks)](https://en.wikipedia.org/wiki/Evil_twin_(wireless_networks)) |
| `watering-hole-attack` | techtarget `/definition/watering-hole-attack` | [Watering hole attack](https://en.wikipedia.org/wiki/Watering_hole_attack) |

### Notes on the approach

- **Replaced rather than removed.** `salting` had this as its *only* resource and would have been left with none, which is the concern raised in #10249 — it gets two replacements.
- **Preferred primary sources.** Where a standards body or the protocol's own specification covers the topic, I used that (IETF RFC 2865, NIST CSRC, OWASP, CISA) rather than another aggregator that can reorganise the same way TechTarget just did.
- **Resource-type ordering preserved** (`@official@` → `@article@` → `@video@`) in every file; `radius` and `rmf` gain an `@official@` link that correctly sorts first.
- **No topic exceeds the 8-link maximum** and no GeeksforGeeks links were added.

### Verification

Every one of the 27 URLs across the 12 changed files was re-checked after the edit. All 12 replacements return `200`. The remaining non-200s are pre-existing links I did not touch and are bot-protection responses, not dead pages (YouTube `429` from my own rate-limited scanning, `iso.org` and `nordvpn.com` `403`).

I also excluded 43 links that return `403` to automated checks — Cloudflare, Cisco, NordVPN and similar serve those to non-browser clients while the pages load fine for real users, so treating them as broken would be a false positive.

Thanks to @gdaffa for the original report.
