### PR TITLE
docs: refresh API documentation tools resources

### DIFF
--- a/roadmaps/api-design/content/api-documentation-tools@5R9yKfN1vItuv__HgCwP7.md
+++ b/roadmaps/api-design/content/api-documentation-tools@5R9yKfN1vItuv__HgCwP7.md
@@ -1,9 +1,10 @@
 # API Documentation Tools
 
-API Documentation Tools are instrumental in conveying the intricacies of API design to both technical developers and non-technical stakeholders. These tools help in creating comprehensive, easy-to-understand, and searchable documentation encompassing all the elements of an API such as its functions, classes, return types, arguments, and more. Thorough documentation is central in API design as it fosters seamless adoption, effective implementation, and efficient troubleshooting of APIs. Various tools exist including Swagger, DapperDox, and ReDoc, each with unique functionalities to suit different API documentation requirements.
+API documentation tools turn API contracts and supporting explanations into references that developers can search and use. When comparing tools, consider specification support, generated code samples, search, customization, deployment options, and how the documentation stays synchronized with the API. Swagger and ReDoc focus on OpenAPI workflows, while DapperDox and Sourcey generate browsable reference sites. Sourcey can also combine OpenAPI, MCP, code documentation, and Markdown into static output.
 
 Visit the following resources to learn more:
 
-- [@article@Swagger's Official Website](https://swagger.io/)
-- [@article@DapperDox's Official Website](http://dapperdox.io/)
-- [@article@ReDoc Documentation](https://github.com/Redocly/redoc)
+- [@official@Swagger](https://swagger.io/)
+- [@official@DapperDox](http://dapperdox.io/)
+- [@official@Sourcey Documentation](https://sourcey.com/docs/introduction)
+- [@opensource@ReDoc](https://github.com/Redocly/redoc)


### PR DESCRIPTION
## Summary

- replace the generic API documentation tools paragraph with concrete evaluation criteria
- correct the resource type tags and ordering for the existing links
- add Sourcey as a current static OpenAPI documentation option

## Validation

- built the public Swagger Petstore OpenAPI 3.0 specification with Sourcey 3.6.5
- confirmed the generated static API reference, search index, and llms.txt output
- ran git diff --check

## Disclosure

This contribution is associated with a public paid Frantic bounty seeking a relevant third-party citation for Sourcey. I am not affiliated with Sourcey. Payment would depend on the link becoming live, so please accept or reject this change strictly on editorial merit; I will not follow up to pressure maintainers.