### PR TITLE
fix: repoint dead angular.dev links in the Angular roadmap

### DIFF
--- a/roadmaps/angular/content/creating-modules@9YhTXybJw2gszlqFeBtW3.md
+++ b/roadmaps/angular/content/creating-modules@9YhTXybJw2gszlqFeBtW3.md
@@ -4,4 +4,4 @@ Creating modules in Angular helps organize your application into manageable, coh
 
 Visit the following resources to learn more:
 
-- [@official@Feature Modules](https://angular.dev/guide/ngmodules/feature-modules)
+- [@official@NgModules](https://angular.dev/guide/ngmodules/overview)

--- a/roadmaps/angular/content/custom-pipes@BOYXGfULJRiP-XOo_lNX3.md
+++ b/roadmaps/angular/content/custom-pipes@BOYXGfULJRiP-XOo_lNX3.md
@@ -4,5 +4,5 @@ Pipes to transform strings, currency amounts, dates, and other data for display.
 
 Visit the following resources to learn more:
 
-- [@official@Custom Pipes for New Transforms](https://angular.dev/guide/pipes/transform-data)
+- [@official@Creating custom pipes](https://angular.dev/guide/templates/pipes#creating-custom-pipes)
 - [@video@Create a custom pipe video for Beginners](https://www.youtube.com/watch?v=P2587FN4Y0w)

--- a/roadmaps/angular/content/feature-modules@w_BazXvINFyxDCHmlznfy.md
+++ b/roadmaps/angular/content/feature-modules@w_BazXvINFyxDCHmlznfy.md
@@ -4,6 +4,6 @@ Feature modules are `NgModules` for the purpose of organizing code. With feature
 
 Visit the following resources to learn more:
 
-- [@official@Feature Modules](https://angular.dev/guide/ngmodules/feature-modules#how-to-make-a-feature-module)
+- [@official@NgModules](https://angular.dev/guide/ngmodules/overview)
 - [@article@Feature module with lazy loading in Angular 15](https://medium.com/@jaydeepvpatil225/feature-module-with-lazy-loading-in-angular-15-53bb8e15d193)
 - [@video@Creating a Feature Module | Understanding Angular Modules](https://www.youtube.com/watch?v=VaPhaexVa1U)

--- a/roadmaps/angular/content/pipes-precedence@nZxZnzbQg9dz-SI65UHq9.md
+++ b/roadmaps/angular/content/pipes-precedence@nZxZnzbQg9dz-SI65UHq9.md
@@ -8,5 +8,5 @@ You should always use parentheses to be sure Angular evaluates the expression as
 
 Visit the following resources to learn more:
 
-- [@official@Precedence](https://angular.dev/guide/pipes/precedence)
+- [@official@Pipe operator precedence](https://angular.dev/guide/templates/pipes#pipe-operator-precedence)
 - [@article@What is the precedence between pipe and ternary operators?](https://iq.js.org/questions/angular/what-is-the-precedence-between-pipe-and-ternary-operators)

--- a/roadmaps/angular/content/transitions--triggers@Iv2d4sgODqMPzA9gH6RAw.md
+++ b/roadmaps/angular/content/transitions--triggers@Iv2d4sgODqMPzA9gH6RAw.md
@@ -4,6 +4,6 @@ In Angular, transition states can be defined explicitly through the `state()` fu
 
 Visit the following resources to learn more:
 
-- [@official@Transition and Triggers](https://angular.dev/guide/animations/transition-and-triggers)
+- [@official@Transition and Triggers](https://angular.dev/guide/legacy-animations/transition-and-triggers)
 - [@video@Angular Animations: Learn the basics](https://www.youtube.com/watch?v=CGBcIz1tYec)
 - [@video@How to use trigger function in Angular Animations](https://www.youtube.com/watch?v=3_B4OV5M_Ag)


### PR DESCRIPTION
## What does this PR do?

Repoints five `@official@` links in the Angular roadmap that currently 404 on angular.dev.

These are easy to miss with a link checker: angular.dev is an SPA that serves its app shell with HTTP 200 for every path, so the links look healthy to any status-code check while a reader lands on the 404 page. I verified each target against the route table (`adev/src/app/routing/navigation-entries/index.ts`) and content in `angular/angular@main` rather than by fetching the URLs.

| Topic | Old (404) | New |
| --- | --- | --- |
| Transitions & Triggers | `/guide/animations/transition-and-triggers` | `/guide/legacy-animations/transition-and-triggers` |
| Feature Modules | `/guide/ngmodules/feature-modules#how-to-make-a-feature-module` | `/guide/ngmodules/overview` |
| Creating Modules | `/guide/ngmodules/feature-modules` | `/guide/ngmodules/overview` |
| Pipes Precedence | `/guide/pipes/precedence` | `/guide/templates/pipes#pipe-operator-precedence` |
| Custom Pipes | `/guide/pipes/transform-data` | `/guide/templates/pipes#creating-custom-pipes` |

## Notes

- **Transitions & Triggers** — the guide moved under `/guide/legacy-animations/`. The old URL matched the content *file* name, which never changed, rather than the route.
- **Feature Modules / Creating Modules** — the `feature-modules` page was removed outright. The NgModules overview is the closest equivalent, and it has no matching heading, so the `#how-to-make-a-feature-module` anchor is dropped rather than remapped. Link labels updated to the destination page title.
- **Pipes** — pipe guides live under `/guide/templates/pipes` now. Both anchors follow adev's slug rule (lowercase, spaces to dashes) and match the live headings.

No node titles, node IDs, or file names were changed, and no links were added or removed.
