### PR TITLE
fix(api-design): correct Resource Modeling title

### DIFF
--- a/roadmaps/api-design/content/resource-modeling@8IDks2DNFZ5nER7wK2Bu4.md
+++ b/roadmaps/api-design/content/resource-modeling@8IDks2DNFZ5nER7wK2Bu4.md
@@ -1,6 +1,4 @@
-# undefined
-
-#Resource Modeling
+# Resource Modeling
 
 Resource modeling is the process of deciding what "things" your API exposes and how they map to URLs. A resource is any noun your API manages, like a user, an order, or a product. Modeling it means defining its boundaries, its relationships to other resources, and what data it carries. Good resource modeling done upfront prevents awkward URL structures and inconsistent data shapes that are painful to fix once consumers are depending on your API.
 


### PR DESCRIPTION
## Description

Fix the API Design roadmap Resource Modeling card title, which currently renders as `undefined`. The content file had an erroneous `# undefined` heading followed by a malformed duplicate heading. This replaces both with the expected `# Resource Modeling` heading.

## Verification

- `git diff --check`
- `pnpm exec prettier --check roadmaps/api-design/content/resource-modeling@8IDks2DNFZ5nER7wK2Bu4.md`