### PR TITLE
Add WebTerm Learn hands-on courses to Linux and Git beginner topics

### DIFF
--- a/roadmaps/git-github-beginner/content/basic-git-usage@PtU5Qwfzn3N1i3oRlCGoR.md
+++ b/roadmaps/git-github-beginner/content/basic-git-usage@PtU5Qwfzn3N1i3oRlCGoR.md
@@ -10,3 +10,4 @@ Visit the following resources to learn more:
 - [@course@Creating a Repository? (Interactive Lesson)](https://inter-git.com/lessons/creating-repository)
 - [@course@Adding Files to Index (Interactive Lesson)](https://inter-git.com/lessons/adding-files-to-index)
 - [@course@Making a Commit (Interactive Lesson)](https://inter-git.com/lessons/making-a-commit)
+- [@course@Git Introduction: init, add, commit, branches and remotes in a browser sandbox (Hands-on)](https://learn.webterm.app/en/courses/git-introduction)

--- a/roadmaps/linux/content/editing-files@HGmeYvRf7_XusZl_K4x9k.md
+++ b/roadmaps/linux/content/editing-files@HGmeYvRf7_XusZl_K4x9k.md
@@ -7,3 +7,4 @@ Visit the following resources to learn more:
 - [@article@Editing Files in Linux Command Line](https://itsfoss.com/edit-files-linux/)
 - [@article@The Complete Guide to Text Editing in Linux with Nano and Vim](https://thelinuxcode.com/how-to-edit-file-in-linux/)
 - [@article@Vim Tutorial for Beginners](https://linuxconfig.org/vim-tutorial)
+- [@course@Vim Introduction: modes, motions and operators in a browser sandbox (Hands-on)](https://learn.webterm.app/en/courses/vim-introduction)

--- a/roadmaps/linux/content/file-permissions@TnrT-cqMA8urew9nLv0Ns.md
+++ b/roadmaps/linux/content/file-permissions@TnrT-cqMA8urew9nLv0Ns.md
@@ -7,3 +7,4 @@ Visit the following resources to learn more:
 - [@article@Linux File Permissions](https://linuxhandbook.com/linux-file-permissions/)
 - [@article@Linux Permissions of Files](https://labex.io/tutorials/linux-permissions-of-files-270252)
 - [@video@Linux File Permissions in 5 Minutes](https://www.youtube.com/watch?v=LnKoncbQBsM)
+- [@course@Terminal Advanced: permissions, sudo and users in a browser sandbox (Hands-on)](https://learn.webterm.app/en/courses/terminal-advanced)

--- a/roadmaps/linux/content/navigation-basics@y7KjVfSI6CAduyHd4mBFT.md
+++ b/roadmaps/linux/content/navigation-basics@y7KjVfSI6CAduyHd4mBFT.md
@@ -9,3 +9,4 @@ Visit the following resources to learn more:
 - [@article@Basic Navigation Commands: cd, ls, and pwd](https://www.linuxbash.sh/post/basic-navigation-commands-cd-ls-and-pwd)
 - [@article@Practice on Linux Fundamentals](https://linuxjourney.com/)
 - [@video@Linux fundamentals](https://www.youtube.com/watch?v=kPylihJRG70&t=1381s&ab_channel=TryHackMe)
+- [@course@Terminal Introduction: navigate the filesystem in a browser sandbox (Hands-on)](https://learn.webterm.app/en/courses/terminal-introduction)

--- a/roadmaps/linux/content/pipe@v32PJl4fzIFTOirOm6G44.md
+++ b/roadmaps/linux/content/pipe@v32PJl4fzIFTOirOm6G44.md
@@ -7,3 +7,4 @@ Visit the following resources to learn more:
 - [@article@An In-Depth Guide to Pipes in Linux - TheLinuxCode](https://thelinuxcode.com/linux-pipe-command-examples/)
 - [@article@Piping and Redirection](https://ryanstutorials.net/linuxtutorial/piping.php#piping)
 - [@article@What is Piping in Linux?](https://linuxsimply.com/what-is-piping-in-linux/)
+- [@course@Terminal Fundamentals: pipes, redirects and grep in a browser sandbox (Hands-on)](https://learn.webterm.app/en/courses/terminal-fundamentals)


### PR DESCRIPTION
Adds one `@course@` link each to five topics where a hands-on, in-browser exercise complements the existing articles and videos:

- `linux` / Navigation Basics → Terminal Introduction
- `linux` / File Permissions → Terminal Advanced (permissions, sudo, users)
- `linux` / Pipe Commands → Terminal Fundamentals (pipes, redirects, grep)
- `linux` / Editing Files → Vim Introduction
- `git-github-beginner` / Basic Git Usage → Git Introduction

All five are free courses on WebTerm Learn. Each lesson opens a simulated Linux terminal in the browser; the learner types real commands and the exercise checks the resulting state (files, permissions, index, branches), so equivalent commands are accepted. The first lesson of each course needs no account; the rest need a free account. No topic exceeds 8 links after this change.

Disclosure: I built WebTerm Learn. I kept it to the topics where the course actually teaches the topic hands-on, and I'm happy to drop any link you consider off-topic.