### PR TITLE
Remove dead resource link from AI Agents topic

### DIFF
--- a/roadmaps/ai-engineer/content/ai-agents@4_ap0rD9Gl6Ep_4jMfPpG.md
+++ b/roadmaps/ai-engineer/content/ai-agents@4_ap0rD9Gl6Ep_4jMfPpG.md
@@ -5,6 +5,5 @@ In AI engineering, "agents" refer to autonomous systems or components that can p
 Visit the following resources to learn more:
 
 - [@article@Building an AI Agent Tutorial - LangChain](https://python.langchain.com/docs/tutorials/agents/)
-- [@article@AI Agents and Their Types](https://play.ht/blog/ai-agents-use-cases/)
 - [@article@How to Design My First AI Agent](https://towardsdatascience.com/how-to-design-my-first-ai-agent/?utm_source=roadmap&utm_medium=Referral&utm_campaign=TDS+roadmap+integration)
 - [@video@The Complete Guide to Building AI Agents for Beginners](https://youtu.be/MOyl58VF2ak?si=-QjRD_5y3iViprJX)


### PR DESCRIPTION
## What
Removed the dead play.ht article link from the AI Agents topic resources.

## Why
play.ht moved their blog off that subdomain and the URL no longer resolves, so the resource is unreachable.

## Verification
DNS for the link fails today; the topic still has other working resources listed.