### PR TITLE
Remove two dead resource links in AI Engineer roadmap

### DIFF
--- a/roadmaps/ai-engineer/content/nanobanana-api@6y73FLjshnqxV8BTGUeiu.md
+++ b/roadmaps/ai-engineer/content/nanobanana-api@6y73FLjshnqxV8BTGUeiu.md
@@ -5,4 +5,3 @@ The NanoBanana API is a tool designed to facilitate the integration and processi
 Visit the following resources to learn more:
 
 - [@official@NanoBanana API](https://nanobananaapi.ai/)
-- [@article@Generating Consistent Imagery with Gemini](https://towardsdatascience.com/generating-consistent-imagery-with-gemini/?utm_source=roadmap&utm_medium=Referral&utm_campaign=TDS+roadmap+integration)

--- a/roadmaps/ai-engineer/content/robust-prompt-engineering@qmx6OHqx4_0JXVIv8dASp.md
+++ b/roadmaps/ai-engineer/content/robust-prompt-engineering@qmx6OHqx4_0JXVIv8dASp.md
@@ -4,5 +4,4 @@ Robust prompt engineering involves carefully crafting inputs to guide AI models 
 
 Visit the following resources to learn more:
 
-- [@article@Building Robust Prompt Engineering Capability](https://aimresearch.co/product/building-robust-prompt-engineering-capability)
 - [@article@Effective Prompt Engineering: A Comprehensive Guide](https://medium.com/@nmurugs/effective-prompt-engineering-a-comprehensive-guide-803160c571ed)


### PR DESCRIPTION
## What
Removes two resource lines whose targets now return 404:

1. "Generating Consistent Imagery with Gemini" (towardsdatascience.com) in the Nano Banana API topic
2. "Building Robust Prompt Engineering Capability" (aimresearch.co) in the Robust Prompt Engineering topic

## Why
Both URLs return 404 on every check (also verified with a plain browser user agent, so it is not bot blocking). Dead resources send learners to error pages.

## Verification
curl with a browser UA returns 404 for both URLs today. Each topic keeps its remaining working resources.