### PR TITLE
cyber-security: add hands-on exercises to nine topics

### DIFF
--- a/roadmaps/cyber-security/content/compliance@05Gbgy6aawYlYIx38u8DE.md
+++ b/roadmaps/cyber-security/content/compliance@05Gbgy6aawYlYIx38u8DE.md
@@ -6,3 +6,4 @@ Visit the following resources to learn more:
 
 - [@article@What is Cyber Security Compliance?](https://www.comptia.org/content/articles/what-is-cybersecurity-compliance)
 - [@article@Cyber Security Compliance 101](https://sprinto.com/blog/cyber-security-compliance/)
+- [@course@GDPR and EU AI Act Compliance Exercises](https://ransomleak.com/catalogue/privacy-compliance/)

--- a/roadmaps/cyber-security/content/dumpster-diving@Iu0Qtk13RjrhHpSlm0uyh.md
+++ b/roadmaps/cyber-security/content/dumpster-diving@Iu0Qtk13RjrhHpSlm0uyh.md
@@ -6,4 +6,5 @@ Visit the following resources to learn more:
 
 - [@article@Dumpster Diving](https://www.techtarget.com/searchsecurity/definition/dumpster-diving)
 - [@article@What is Dumpster Diving](https://powerdmarc.com/dumpster-diving-in-cybersecurity/)
+- [@course@Secure Document Disposal: Interactive Office Exercise](https://ransomleak.com/exercises/secure-document-disposal/)
 - [@video@Dumpster Diving for Sensitive Information](https://www.youtube.com/watch?v=Pom86gq4mk4)

--- a/roadmaps/cyber-security/content/learn-how-malware-works-and-types@v7CD_sHqLWbm9ibXXESIK.md
+++ b/roadmaps/cyber-security/content/learn-how-malware-works-and-types@v7CD_sHqLWbm9ibXXESIK.md
@@ -1,3 +1,7 @@
 # Malware Analysis and Types
 
 Malware, short for malicious software, refers to any program or code designed to harm, disrupt, or gain unauthorized access to computer systems, networks, or devices. This encompasses various forms like viruses that replicate themselves, worms that self-propagate across networks, Trojans disguised as legitimate software, ransomware that encrypts data for extortion, spyware that secretly monitors user activity, and adware that displays unwanted advertisements. Understanding the mechanisms and characteristics of different malware types is essential for effective detection, prevention, and mitigation of cyber threats.
+
+Visit the following resources to learn more:
+
+- [@course@Ransomware: Interactive Attack Walkthrough](https://ransomleak.com/exercises/ransomware/)

--- a/roadmaps/cyber-security/content/mfa--2fa@pnfVrOjDeG1uYAeqHxhJP.md
+++ b/roadmaps/cyber-security/content/mfa--2fa@pnfVrOjDeG1uYAeqHxhJP.md
@@ -6,3 +6,4 @@ Visit the following resources to learn more:
 
 - [@article@What is MFA?](https://www.onelogin.com/learn/what-is-mfa)
 - [@article@What is 2FA?](https://www.microsoft.com/en-gb/security/business/security-101/what-is-two-factor-authentication-2fa)
+- [@course@MFA Fatigue Attack: Interactive Exercise](https://ransomleak.com/exercises/mfa-fatigue-attack/)

--- a/roadmaps/cyber-security/content/phishing@7obusm5UtHwWMcMMEB3lt.md
+++ b/roadmaps/cyber-security/content/phishing@7obusm5UtHwWMcMMEB3lt.md
@@ -6,5 +6,6 @@ Visit the following resources to learn more:
 
 - [@article@How to Recognize and Avoid Phishing Scams](https://consumer.ftc.gov/articles/how-recognize-and-avoid-phishing-scams)
 - [@article@Recognize and Report Phishing](https://www.cisa.gov/secure-our-world/recognize-and-report-phishing)
+- [@course@Phishing: Hands-on Exercise in a Simulated Inbox](https://ransomleak.com/exercises/phishing/)
 - [@video@Protect yourself from phishing](https://support.microsoft.com/en-us/windows/protect-yourself-from-phishing-0c7ea947-ba98-3bd9-7184-430e1f860a44)
 - [@video@Phishing attacks are SCARY easy to do!! (let me show you!)](https://www.youtube.com/watch?v=u9dBGWVwMMA)

--- a/roadmaps/cyber-security/content/shoulder-surfing@FD0bkmxNpPXiUB_NevEUf.md
+++ b/roadmaps/cyber-security/content/shoulder-surfing@FD0bkmxNpPXiUB_NevEUf.md
@@ -7,3 +7,4 @@ Visit the following resources to learn more:
 - [@article@What is Shoulder Surfing, and How can you avoid it?](https://nordvpn.com/blog/shoulder-surfing/?srsltid=AfmBOorl5NPpW_Tnhas9gB2HiblorqwXyK0NJae7uaketrnDwbjJmiYV)
 - [@article@What is Shoulder Surfing?](https://www.mcafee.com/learn/what-is-shoulder-surfing/)
 - [@article@What is Shoulder Surfing? 9 ways to protect yourself](https://www.bigrock.in/blog/products/security/what-is-shoulder-surfing-9-ways-to-protect-yourself-from-shoulder-surfing/)
+- [@course@Clean Desk Basics: Interactive Office Exercise](https://ransomleak.com/exercises/clean-desk-basics/)

--- a/roadmaps/cyber-security/content/social-engineering@O1VceThdxRlgQ6DcGyY7Y.md
+++ b/roadmaps/cyber-security/content/social-engineering@O1VceThdxRlgQ6DcGyY7Y.md
@@ -5,4 +5,5 @@ Social Engineering is a manipulation technique that exploits human psychology to
 Visit the following resources to learn more:
 
 - [@article@What Is Social Engineering?](https://www.cisco.com/c/en/us/products/security/what-is-social-engineering.html)
+- [@course@Social Engineering: Interactive Pretexting Exercise](https://ransomleak.com/exercises/social-engineering/)
 - [@video@Social Engineering Explained](https://www.youtube.com/shorts/DdCSraNCxhs)

--- a/roadmaps/cyber-security/content/understand-the-concept-of-security-in-the-cloud@ThLsXkqLw--uddHz0spCH.md
+++ b/roadmaps/cyber-security/content/understand-the-concept-of-security-in-the-cloud@ThLsXkqLw--uddHz0spCH.md
@@ -6,4 +6,5 @@ Visit the following resources to learn more:
 
 - [@article@What Is Cloud Security? - Google Cloud](https://cloud.google.com/learn/what-is-cloud-security)
 - [@article@Cloud Security](https://www.checkpoint.com/cyber-hub/cloud-security/what-is-cloud-security/)
+- [@course@Cloud Security Labs: S3, IAM, Metadata, Containers](https://ransomleak.com/catalogue/cloud-security/)
 - [@video@What is cloud security](https://www.youtube.com/watch?v=jI8IKpjiCSM)

--- a/roadmaps/cyber-security/content/web-based-attacks-and-owasp10@fyOYVqiBqyKC4aqc6-y0q.md
+++ b/roadmaps/cyber-security/content/web-based-attacks-and-owasp10@fyOYVqiBqyKC4aqc6-y0q.md
@@ -6,4 +6,5 @@ Visit the following resources to learn more:
 
 - [@official@OWASP Top Ten](https://owasp.org/www-project-top-ten/)
 - [@official@OWASP Vulnerable Web Applications Directory (VWAD)](https://vwad.owasp.org/)
+- [@course@OWASP Top 10 Exploit-then-Fix Labs](https://ransomleak.com/catalogue/application-security/)
 - [@video@OWASP Top Ten](https://youtube.com/playlist?list=PLyqga7AXMtPOguwtCCXGZUKvd2CDCmUgQ&si=ZYRbcDSRvqTOnDOo)


### PR DESCRIPTION
Adds one `@course@` link to nine cyber-security topics that currently have only articles and videos, so a learner can practise the concept instead of only reading about it. Every link opens a browser-based exercise with no account, email, or payment, and every topic stays well under the eight-link cap.

| Topic | Links before | Added |
|---|---|---|
| Phishing | 4 | Work a suspicious email in a simulated inbox: sender spoofing, link targets, urgency cues |
| Social Engineering | 2 | Take a pretext phone call and practise holding a verification procedure under pressure |
| MFA / 2FA | 2 | MFA fatigue attack: repeated push prompts plus a fake help-desk nudge |
| OWASP Top 10 and Web-Based Attacks | 3 | Exploit-then-fix labs for each OWASP Top 10 category |
| Compliance | 2 | GDPR and EU AI Act exercises: lawful bases, DSARs, breach response, AI literacy |
| Malware Analysis and Types | 0 (no resources block yet) | The first minutes of a ransomware infection, decision by decision |
| Cloud Security Concepts | 3 | Public buckets, over-permissive IAM, instance metadata abuse, container escapes |
| Dumpster Diving | 3 | Bin a restricted HR printout, then read it back from the skip; what disposal should have looked like |
| Shoulder Surfing | 3 | Leave a desk with the screen unlocked and a password on a note, then see who used it |

The Malware topic had no "Visit the following resources" block, so this adds one in the standard format. Links are placed in the type order from contributing.md (after articles, before videos).

Disclosure: I work on RansomLeak, which hosts these exercises. They are free for individual learners with no sign-up, so they fit the "genuinely adds value" bar rather than a promotional link to a landing page. Happy to trim to fewer topics if you would rather start smaller.