### PR TITLE
Fix typos in AI engineer roadmap

### DIFF
--- a/roadmaps/ai-engineer/content/codex@XY2l96sry3WyLzzo3KUeU.md
+++ b/roadmaps/ai-engineer/content/codex@XY2l96sry3WyLzzo3KUeU.md
@@ -4,5 +4,5 @@ Codex is an AI model created by OpenAI that translates natural language into cod
 
 Visit the following resources to learn more:
 
-- [@official@Codex - Official Webste](https://chatgpt.com/codex)
+- [@official@Codex - Official Website](https://chatgpt.com/codex)
 - [@video@Getting started with Codex](https://www.youtube.com/watch?v=px7XlbYgk7I)

--- a/roadmaps/ai-engineer/content/model-context-protocol-mcp@AeHkNU-uJ_gBdo5-xdpEu.md
+++ b/roadmaps/ai-engineer/content/model-context-protocol-mcp@AeHkNU-uJ_gBdo5-xdpEu.md
@@ -7,4 +7,4 @@ Visit the following resources to learn more:
 - [@course@Model Context Protocol (MCP) Course](https://huggingface.co/learn/mcp-course/en/unit0/introduction)
 - [@official@Model Context Protocol](https://modelcontextprotocol.io/)
 - [@opensource@Model Context Protocol](https://github.com/modelcontextprotocol)
-- [@article@Discover more aritlces on MCP](https://towardsdatascience.com/tag/mcp/?utm_source=roadmap&utm_medium=Referral&utm_campaign=TDS+roadmap+integration)
+- [@article@Discover more articles on MCP](https://towardsdatascience.com/tag/mcp/?utm_source=roadmap&utm_medium=Referral&utm_campaign=TDS+roadmap+integration)


### PR DESCRIPTION
Fixed spelling errors in two AI engineer roadmap resource titles:

- Webste → Website
- aritlces → articles

No functional changes were made.