### PR TITLE
docs: fix contributing.md links/formatting and add typecheck script

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -9,7 +9,7 @@ First of all, thank you for considering to contribute. Please look at the detail
   - [How To Structure Content](#how-to-structure-content)
 - [Guidelines](#guidelines)
 - [Good vs. Not So Good Contributions](#good-vs-not-so-good-contributions)
-- [Local Development](#local-development)
+- [Working Locally](#working-locally)
 
 ## New Roadmaps
 
@@ -95,21 +95,17 @@ It's important to add a valid type, this will help us categorize the content and
 - <p><strong>Adding everything available out there is not the goal!</strong><br/>
 
   The roadmaps represent the skillset most valuable today, i.e., if you were to enter any of the listed fields today, what would you learn? There might be things that are of-course being used today, but prioritize the things that are most in demand today, e.g., agree that lots of people are using angular.js today, but you wouldn't want to learn that instead of React, Angular, or Vue. Use your critical thinking to filter out non-essential stuff. Give honest arguments for why the resource should be included.</p>
+  
+- **Do not add things you have not evaluated personally!**  
+  Use your critical thinking to filter out non-essential stuff. Give honest arguments for why the resource should be included. Have you read this book? Can you give a short article?
 
-- <p><strong>Do not add things you have not evaluated personally!</strong><br/>
+- **Create a Single PR for Content Additions**  
+  If you are planning to contribute by adding content to the roadmaps, I recommend you to clone the repository, add content to the [content directory of the roadmap](./roadmaps/) and create a single PR.
 
-  Use your critical thinking to filter out non-essential stuff. Give honest arguments for why the resource should be included. Have you read this book? Can you give a short article?</p>
-
-- <p><strong>Create a Single PR for Content Additions</strong></p>
-
-  If you are planning to contribute by adding content to the roadmaps, I recommend you to clone the repository, add content to the [content directory of the roadmap](./roadmaps/) and create a single PR to make it easier for me to review and merge the PR.
-
-- <p><strong>Write meaningful commit messages</strong><br/>
-
+- **Write meaningful commit messages**  
   Meaningful commit messages help speed up the review process as well as help other contributors gain a good overview of the repositories commit history without having to dive into every commit.
 
-  </p>
-- <p><strong>Look at the existing issues/pull requests before opening new ones</strong></p>
+- **Look at the existing issues/pull requests before opening new ones**
 
 ## Good vs. Not So Good Contributions
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "description": "Roadmap content for roadmap.sh",
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
     "sync:content-to-repo": "tsx ./scripts/sync-content-to-repo.ts",
     "sync:repo-to-database": "tsx ./scripts/sync-repo-to-database.ts",


### PR DESCRIPTION
### Description
This PR addresses formatting issues and broken links in `contributing.md`, as well as missing type verification tooling in `package.json`.

### Changes Made
- **Fixed TOC Link**: Updated the Table of Contents link from `#local-development` to `#working-locally` to match the actual section heading.
- **Cleaned HTML formatting**: Replaced raw, unclosed `<p>` and `<br/>` tags with standard Markdown bullet formatting in the Guidelines section.
- **Added `typecheck` script**: Added `"typecheck": "tsc --noEmit"` to `package.json` to allow contributors and CI to verify TypeScript scripts.

### Verification
- Checked Markdown preview in editor to confirm anchor jump and rendering.
- Tested locally with `npm run typecheck`, exiting with code `0` (no type errors).

Closes #10295 