### PR TITLE
roadmaps: add hands-on security exercises to 17 topics

### DIFF
--- a/roadmaps/ai-engineer/content/security-and-privacy-concerns@sWBT-j2cRuFqRFYtV_5TK.md
+++ b/roadmaps/ai-engineer/content/security-and-privacy-concerns@sWBT-j2cRuFqRFYtV_5TK.md
@@ -5,4 +5,5 @@ Security and privacy concerns in AI revolve around the protection of data and th
 Visit the following resources to learn more:
 
 - [@article@Examining Privacy Risks in AI Systems](https://transcend.io/blog/ai-and-privacy)
+- [@course@AI Security Labs: OWASP LLM, Agentic and MCP Top 10](https://ransomleak.com/catalogue/ai-security/)
 - [@video@AI Is Dangerous, but Not for the Reasons You Think | Sasha Luccioni | TED](https://www.youtube.com/watch?v=eXdVDhOGqoE)

--- a/roadmaps/ai-red-teaming/content/agentic-ai-security@FVsKivsJrIb82B0lpPmgw.md
+++ b/roadmaps/ai-red-teaming/content/agentic-ai-security@FVsKivsJrIb82B0lpPmgw.md
@@ -8,3 +8,4 @@ Visit the following resources to learn more:
 - [@article@EmbraceTheRed](https://embracethered.com/)
 - [@official@Model Context Protocol - Authorization Specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
 - [@article@GitHub MCP Exploited: Accessing Private Repositories via MCP - Invariant Labs](https://invariantlabs.ai/blog/mcp-github-vulnerability)
+- [@course@Agentic Goal Hijacking: Hands-on Exercise](https://ransomleak.com/exercises/agentic-goal-hijack/)

--- a/roadmaps/ai-red-teaming/content/llm-security-testing@xJYTRbPxMn0Xs5ea0Ygn6.md
+++ b/roadmaps/ai-red-teaming/content/llm-security-testing@xJYTRbPxMn0Xs5ea0Ygn6.md
@@ -7,3 +7,4 @@ Visit the following resources to learn more:
 - [@course@AI Red Teaming Courses - Learn Prompting](https://learnprompting.org/blog/ai-red-teaming-courses)
 - [@article@SecBench: A Comprehensive Multi-Dimensional Benchmarking Dataset for LLMs in Cybersecurity](https://arxiv.org/abs/2412.20787)
 - [@article@The Ultimate Guide to Red Teaming LLMs and Adversarial Prompts (Kili Technology)](https://kili-technology.com/large-language-models-llms/red-teaming-llms-and-adversarial-prompts)
+- [@course@OWASP LLM, Agentic and MCP Top 10: Exploit-then-Fix Labs](https://ransomleak.com/catalogue/ai-security/)

--- a/roadmaps/ai-red-teaming/content/prompt-injection@XOrAPDRhBvde9R-znEipH.md
+++ b/roadmaps/ai-red-teaming/content/prompt-injection@XOrAPDRhBvde9R-znEipH.md
@@ -9,3 +9,4 @@ Visit the following resources to learn more:
 - [@article@Prompt Injection (Learn Prompting)](https://learnprompting.org/docs/prompt_hacking/injection)
 - [@article@Prompt Injection Attack Explanation (IBM)](https://research.ibm.com/blog/prompt-injection-attacks-against-llms)
 - [@article@Prompt Injection: Impact, How It Works & 4 Defense Measures](https://www.tigera.io/learn/guides/llm-security/prompt-injection/)
+- [@course@Prompt Injection: Hands-on Exercise Against a Live Assistant](https://ransomleak.com/exercises/clawdbot-prompt-injection/)

--- a/roadmaps/aws/content/iam@xmKeB4hEi2DunmhAsvS1X.md
+++ b/roadmaps/aws/content/iam@xmKeB4hEi2DunmhAsvS1X.md
@@ -5,3 +5,4 @@ IAM, or Identity and Access Management, in AWS is a service that enables you to 
 Visit the following resources to learn more:
 
 - [@official@IAM - User Guide](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html)
+- [@course@Over-Permissive IAM: Hands-on Privilege Escalation Exercise](https://ransomleak.com/exercises/over-permissive-iam/)

--- a/roadmaps/aws/content/s3@PN3xAYfQ-_QgZCRCnsEca.md
+++ b/roadmaps/aws/content/s3@PN3xAYfQ-_QgZCRCnsEca.md
@@ -5,3 +5,4 @@ Amazon S3 (Simple Storage Service) is an object storage service offered by Amazo
 Visit the following resources to learn more:
 
 - [@official@S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)
+- [@course@Public S3 Buckets: Hands-on Exercise](https://ransomleak.com/exercises/public-storage-buckets/)

--- a/roadmaps/aws/content/security-groups@Cd9gdbkCFdrTLrnJMy5F3.md
+++ b/roadmaps/aws/content/security-groups@Cd9gdbkCFdrTLrnJMy5F3.md
@@ -5,3 +5,4 @@ Security Groups in AWS act as a virtual firewall for your instance to control in
 Visit the following resources to learn more:
 
 - [@official@Security Groups](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-groups.html)
+- [@course@Cloud Network Exposure: Hands-on Security Group Exercise](https://ransomleak.com/exercises/cloud-network-exposure/)

--- a/roadmaps/backend/content/authentication@PY9G7KQy8bF6eIdr1ydHf.md
+++ b/roadmaps/backend/content/authentication@PY9G7KQy8bF6eIdr1ydHf.md
@@ -10,3 +10,4 @@ Visit the following resources to learn more:
 - [@article@JWT Authentication](https://roadmap.sh/guides/jwt-authentication)
 - [@article@OAuth - Open Authorization](https://roadmap.sh/guides/oauth)
 - [@article@SSO - Single Sign On](https://roadmap.sh/guides/sso)
+- [@course@Broken Authentication: Hands-on Exercise](https://ransomleak.com/exercises/broken-user-authentication/)

--- a/roadmaps/backend/content/owasp-risks@AAgciyxuDvS2B_c6FRMvT.md
+++ b/roadmaps/backend/content/owasp-risks@AAgciyxuDvS2B_c6FRMvT.md
@@ -8,3 +8,4 @@ Visit the following resources to learn more:
 - [@opensource@OWASP Application Security Verification Standard](https://github.com/OWASP/ASVS)
 - [@article@OWASP Top 10 Security Risks](https://cheatsheetseries.owasp.org/IndexTopTen.html)
 - [@article@OWASP Cheatsheets](https://cheatsheetseries.owasp.org/cheatsheets/AJAX_Security_Cheat_Sheet.html)
+- [@course@OWASP Top 10: Exploit-then-Fix Labs](https://ransomleak.com/catalogue/application-security/)

--- a/roadmaps/devops/content/secret-management@hcrPpjFxPi_iLiMdLKJrO.md
+++ b/roadmaps/devops/content/secret-management@hcrPpjFxPi_iLiMdLKJrO.md
@@ -6,4 +6,5 @@ Visit the following resources to learn more:
 
 - [@article@How to Manage Secrets in Web Applications?](https://cs.fyi/guide/secret-management-best-practices)
 - [@article@Why DevSecOps Teams Need Secrets Management](https://www.keepersecurity.com/blog/2023/01/26/why-devsecops-teams-need-secrets-management/)
+- [@course@CI/CD Secret Exposure: Hands-on Exercise](https://ransomleak.com/exercises/cicd-secret-exposure/)
 - [@video@DevOps Tricks for Managing Secrets in Production](https://www.youtube.com/watch?v=u_L-f7Th_7o)

--- a/roadmaps/docker/content/container-security@78YFahP3Fg-c27reLkuK4.md
+++ b/roadmaps/docker/content/container-security@78YFahP3Fg-c27reLkuK4.md
@@ -6,3 +6,4 @@ Visit the following resources to learn more:
 
 - [@official@Docker Security](https://docs.docker.com/engine/security/)
 - [@article@Kubernetes Security Best Practices](https://www.aquasec.com/cloud-native-academy/kubernetes-in-production/kubernetes-security-best-practices-10-steps-to-securing-k8s/)
+- [@course@Container Security Labs: Privileged Containers, Daemon Exposure, Image Layers](https://ransomleak.com/catalogue/cloud-security/)

--- a/roadmaps/docker/content/image-security@M5UG-ZcyhBPbksZd0ZdNt.md
+++ b/roadmaps/docker/content/image-security@M5UG-ZcyhBPbksZd0ZdNt.md
@@ -6,3 +6,4 @@ Visit the following resources to learn more:
 
 - [@official@Docker Content Trust](https://docs.docker.com/engine/security/trust/content_trust/)
 - [@official@Docker Hub](https://hub.docker.com/)
+- [@course@Secrets in Image Layers: Hands-on Exercise](https://ransomleak.com/exercises/secrets-in-image-layers/)

--- a/roadmaps/docker/content/runtime-security@vYug8kcwrMoWf8ft4UDNI.md
+++ b/roadmaps/docker/content/runtime-security@vYug8kcwrMoWf8ft4UDNI.md
@@ -6,3 +6,4 @@ Visit the following resources to learn more:
 
 - [@official@Docker Security](https://docs.docker.com/engine/security/)
 - [@official@Docker Security Best Practices](https://docs.docker.com/build/building/best-practices/)
+- [@course@Privileged Containers: Hands-on Escape Exercise](https://ransomleak.com/exercises/privileged-containers/)

--- a/roadmaps/docker/content/using-3rd-party-container-images@LShK3-1EGGuXnEvdScFR7.md
+++ b/roadmaps/docker/content/using-3rd-party-container-images@LShK3-1EGGuXnEvdScFR7.md
@@ -5,3 +5,4 @@ Third-party images are pre-built Docker container images that are available on D
 Visit the following resources to learn more:
 
 - [@official@Docker Hub Registry](https://hub.docker.com/)
+- [@course@Malicious Base Images: Hands-on Exercise](https://ransomleak.com/exercises/malicious-base-images/)

--- a/roadmaps/git-github/content/github-security@f2PG4t6iVtfIH8BVe5H7f.md
+++ b/roadmaps/git-github/content/github-security@f2PG4t6iVtfIH8BVe5H7f.md
@@ -7,3 +7,4 @@ Visit the following resources to learn more:
 - [@official@GitHub security features](https://docs.github.com/en/code-security/getting-started/github-security-features)
 - [@official@Dependabot Quick-start Guide](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide)
 - [@official@About user alerts](https://docs.github.com/en/code-security/secret-scanning/managing-alerts-from-secret-scanning/about-alerts#about-user-alerts)
+- [@course@Git and Repository Security: Hands-on Labs](https://ransomleak.com/catalogue/git-security/)

--- a/roadmaps/git-github/content/secrets-and-env-vars@aflP7oWsQzAr4YPo2LLiQ.md
+++ b/roadmaps/git-github/content/secrets-and-env-vars@aflP7oWsQzAr4YPo2LLiQ.md
@@ -6,4 +6,5 @@ Visit the following resources to learn more:
 
 - [@official@Using secrets in GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions)
 - [@official@Store information in variables](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables)
+- [@course@CI/CD Secret Exposure: Hands-on Exercise](https://ransomleak.com/exercises/cicd-secret-exposure/)
 - [@video@Secrets and Environment Variables in your GitHub Action](https://www.youtube.com/watch?v=dPLPSaFqJmY)

--- a/roadmaps/prompt-engineering/content/prompt-injection@6W_ONYREbXHwPigoDx1cW.md
+++ b/roadmaps/prompt-engineering/content/prompt-injection@6W_ONYREbXHwPigoDx1cW.md
@@ -6,4 +6,5 @@ Visit the following resources to learn more:
 
 - [@official@Mitigate jailbreaks and prompt injections - Anthropic](https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/mitigate-jailbreaks)
 - [@official@LLM01:2025 Prompt Injection - OWASP](https://genai.owasp.org/llmrisk/llm01-prompt-injection/)
+- [@course@Prompt Injection: Hands-on Exercise Against a Live Assistant](https://ransomleak.com/exercises/clawdbot-prompt-injection/)
 - [@video@What Is a Prompt Injection Attack?](https://www.youtube.com/watch?v=jrHRe9lSqqA)


### PR DESCRIPTION
Follow-up to #10287 (cyber-security), which you merged this morning. Same pattern: one `@course@` link per topic, pointing at a browser-based exercise where the learner reproduces the problem and then fixes it. No account, sign-up or local setup, and every topic stays well under the eight-link cap.

Consolidated into a single PR per the contributing guidelines.

**docker**

| Topic | Links before | What the exercise makes you do |
|---|---|---|
| Container Security | 2 | Labs on privileged containers, exposed daemon, secrets in image layers, registry exposure |
| Image Security | 2 | Pull a secret out of a built image's layers, then rebuild without the leak |
| Runtime Security | 2 | Escape a privileged container, then apply the constraints that prevent it |
| Using Third Party Images | 1 | Inspect a malicious base image from a public registry and trace what it added |

**aws** (each of these had only the AWS user guide)

| Topic | Links before | What the exercise makes you do |
|---|---|---|
| IAM | 1 | Escalate privilege through an over-permissive policy, then scope it down |
| S3 | 1 | Find and read a bucket nobody meant to publish, then fix the access settings |
| Security Groups | 1 | Reach a service exposed by an over-broad rule, then close it |

**ai-red-teaming**

| Topic | Links before | What the exercise makes you do |
|---|---|---|
| Prompt Injection | 5 | Inject instructions into a live assistant's context, then see the mitigation |
| Agentic AI Security | 4 | Hijack an agent's goal mid-task, matching the goal-hijacking risk the topic describes |
| LLM Security Testing | 3 | The OWASP LLM, Agentic and MCP Top 10 track, one exploit-then-fix exercise per risk |

I left Jailbreak Techniques alone because we have no exercise that genuinely matches it, and I would rather not stretch a link to fit.

**prompt-engineering**

| Topic | Links before | What the exercise makes you do |
|---|---|---|
| Prompt Injection | 3 | The existing links describe the attack; this one has you perform it and then defend against it |

**git-github**

| Topic | Links before | What the exercise makes you do |
|---|---|---|
| GitHub Security | 3 | Secrets in commit history, exposed .git directories, commit author spoofing, branch-protection bypass, malicious pull requests |
| Secrets and Env Vars | 3 | Leak a secret through a workflow, find it in the run logs, then store and reference it correctly |

**backend**

| Topic | Links before | What the exercise makes you do |
|---|---|---|
| OWASP Security Risks | 4 | The OWASP Top 10 as exploit-then-fix labs: SQL injection, stored and reflected XSS, SSRF, XXE, CSRF, privilege escalation |
| Authentication | 6 | Break a weak authentication flow, then apply the fix |

**devops**

| Topic | Links before | What the exercise makes you do |
|---|---|---|
| Secret Management | 3 | Leak a secret through a pipeline, find it in the run logs, then store and reference it correctly |

**ai-engineer**

| Topic | Links before | What the exercise makes you do |
|---|---|---|
| Security and Privacy Concerns | 2 | Hands-on labs for the OWASP LLM, Agentic and MCP Top 10 |

Links are placed in the type order from contributing.md (after official/article, before video). The small deletion count is the missing trailing newline on the last line of each file, which I kept as-is.

Disclosure: I work on RansomLeak, which hosts these exercises. They are free for individual learners with no sign-up.