### PR TITLE
aws: add hands-on security exercises to IAM, S3 and Security Groups

### DIFF
--- a/roadmaps/aws/content/iam@xmKeB4hEi2DunmhAsvS1X.md
+++ b/roadmaps/aws/content/iam@xmKeB4hEi2DunmhAsvS1X.md
@@ -5,3 +5,4 @@ IAM, or Identity and Access Management, in AWS is a service that enables you to 
 Visit the following resources to learn more:
 
 - [@official@IAM - User Guide](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html)
+- [@course@Over-Permissive IAM: Hands-on Privilege Escalation Exercise](https://ransomleak.com/exercises/over-permissive-iam/)

--- a/roadmaps/aws/content/s3@PN3xAYfQ-_QgZCRCnsEca.md
+++ b/roadmaps/aws/content/s3@PN3xAYfQ-_QgZCRCnsEca.md
@@ -5,3 +5,4 @@ Amazon S3 (Simple Storage Service) is an object storage service offered by Amazo
 Visit the following resources to learn more:
 
 - [@official@S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)
+- [@course@Public S3 Buckets: Hands-on Exercise](https://ransomleak.com/exercises/public-storage-buckets/)

--- a/roadmaps/aws/content/security-groups@Cd9gdbkCFdrTLrnJMy5F3.md
+++ b/roadmaps/aws/content/security-groups@Cd9gdbkCFdrTLrnJMy5F3.md
@@ -5,3 +5,4 @@ Security Groups in AWS act as a virtual firewall for your instance to control in
 Visit the following resources to learn more:
 
 - [@official@Security Groups](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-groups.html)
+- [@course@Cloud Network Exposure: Hands-on Security Group Exercise](https://ransomleak.com/exercises/cloud-network-exposure/)


### PR DESCRIPTION
Each of these three topics currently links only to the AWS user guide. This adds one `@course@` link per topic to a browser-based exercise where the learner exploits the common misconfiguration and then fixes it. No AWS account is needed, which makes them usable at the point in the roadmap where a learner has read the docs but has nothing safe to practise on.

| Topic | Links before | Added |
|---|---|---|
| IAM | 1 | Escalate privilege through an over-permissive policy, then scope it down |
| S3 | 1 | Find and read a bucket nobody meant to publish, then correct the access settings |
| Security Groups | 1 | Reach a service exposed by an over-broad rule, then close it |

Disclosure: I work on RansomLeak, which hosts these exercises. They are free for individual learners with no sign-up. Same format as #10287, which was merged into the cyber-security roadmap.

https://claude.ai/code/session_01N4UCQWsmoH6URE6YjxPWgX