### PR TITLE
ai-red-teaming: add hands-on exercises to three topics

### DIFF
--- a/roadmaps/ai-red-teaming/content/agentic-ai-security@FVsKivsJrIb82B0lpPmgw.md
+++ b/roadmaps/ai-red-teaming/content/agentic-ai-security@FVsKivsJrIb82B0lpPmgw.md
@@ -8,3 +8,4 @@ Visit the following resources to learn more:
 - [@article@EmbraceTheRed](https://embracethered.com/)
 - [@official@Model Context Protocol - Authorization Specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
 - [@article@GitHub MCP Exploited: Accessing Private Repositories via MCP - Invariant Labs](https://invariantlabs.ai/blog/mcp-github-vulnerability)
+- [@course@Agentic Goal Hijacking: Hands-on Exercise](https://ransomleak.com/exercises/agentic-goal-hijack/)

--- a/roadmaps/ai-red-teaming/content/llm-security-testing@xJYTRbPxMn0Xs5ea0Ygn6.md
+++ b/roadmaps/ai-red-teaming/content/llm-security-testing@xJYTRbPxMn0Xs5ea0Ygn6.md
@@ -7,3 +7,4 @@ Visit the following resources to learn more:
 - [@course@AI Red Teaming Courses - Learn Prompting](https://learnprompting.org/blog/ai-red-teaming-courses)
 - [@article@SecBench: A Comprehensive Multi-Dimensional Benchmarking Dataset for LLMs in Cybersecurity](https://arxiv.org/abs/2412.20787)
 - [@article@The Ultimate Guide to Red Teaming LLMs and Adversarial Prompts (Kili Technology)](https://kili-technology.com/large-language-models-llms/red-teaming-llms-and-adversarial-prompts)
+- [@course@OWASP LLM, Agentic and MCP Top 10: Exploit-then-Fix Labs](https://ransomleak.com/catalogue/ai-security/)

--- a/roadmaps/ai-red-teaming/content/prompt-injection@XOrAPDRhBvde9R-znEipH.md
+++ b/roadmaps/ai-red-teaming/content/prompt-injection@XOrAPDRhBvde9R-znEipH.md
@@ -9,3 +9,4 @@ Visit the following resources to learn more:
 - [@article@Prompt Injection (Learn Prompting)](https://learnprompting.org/docs/prompt_hacking/injection)
 - [@article@Prompt Injection Attack Explanation (IBM)](https://research.ibm.com/blog/prompt-injection-attacks-against-llms)
 - [@article@Prompt Injection: Impact, How It Works & 4 Defense Measures](https://www.tigera.io/learn/guides/llm-security/prompt-injection/)
+- [@course@Prompt Injection: Hands-on Exercise Against a Live Assistant](https://ransomleak.com/exercises/clawdbot-prompt-injection/)


### PR DESCRIPTION
Adds one `@course@` link to three topics where the existing resources are articles and papers, so a learner can run the attack rather than only read about it.

| Topic | Links before | Added |
|---|---|---|
| Prompt Injection | 5 | Inject instructions into a live assistant's context and observe the override, then see the mitigation |
| Agentic AI Security | 4 | Hijack an agent's goal mid-task, matching the goal-hijacking risk the topic describes |
| LLM Security Testing | 3 | The full OWASP LLM, Agentic and MCP Top 10 track, one exploit-then-fix exercise per risk |

I left Jailbreak Techniques alone because we have no exercise that genuinely matches it, and I would rather not stretch a link to fit.

Disclosure: I work on RansomLeak, which hosts these exercises. They are free for individual learners with no sign-up. Same format as #10287, which was merged into the cyber-security roadmap.

https://claude.ai/code/session_01N4UCQWsmoH6URE6YjxPWgX