### PR TITLE
prompt-engineering: add a hands-on prompt injection exercise

### DIFF
--- a/roadmaps/prompt-engineering/content/prompt-injection@6W_ONYREbXHwPigoDx1cW.md
+++ b/roadmaps/prompt-engineering/content/prompt-injection@6W_ONYREbXHwPigoDx1cW.md
@@ -6,4 +6,5 @@ Visit the following resources to learn more:
 
 - [@official@Mitigate jailbreaks and prompt injections - Anthropic](https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/mitigate-jailbreaks)
 - [@official@LLM01:2025 Prompt Injection - OWASP](https://genai.owasp.org/llmrisk/llm01-prompt-injection/)
+- [@course@Prompt Injection: Hands-on Exercise Against a Live Assistant](https://ransomleak.com/exercises/clawdbot-prompt-injection/)
 - [@video@What Is a Prompt Injection Attack?](https://www.youtube.com/watch?v=jrHRe9lSqqA)


### PR DESCRIPTION
The Prompt Injection topic currently links to the Anthropic mitigation guide, the OWASP entry and an explainer video, all of which describe the attack. This adds one `@course@` link to a browser exercise where the learner performs the injection against a live assistant and then sees which mitigation stops it. Free, no sign-up.

Disclosure: I work on RansomLeak, which hosts these exercises. They are free for individual learners with no sign-up. Same format as #10287, which was merged into the cyber-security roadmap.

https://claude.ai/code/session_01N4UCQWsmoH6URE6YjxPWgX