### PR TITLE
git-github: add hands-on security labs to two topics

### DIFF
--- a/roadmaps/git-github/content/github-security@f2PG4t6iVtfIH8BVe5H7f.md
+++ b/roadmaps/git-github/content/github-security@f2PG4t6iVtfIH8BVe5H7f.md
@@ -7,3 +7,4 @@ Visit the following resources to learn more:
 - [@official@GitHub security features](https://docs.github.com/en/code-security/getting-started/github-security-features)
 - [@official@Dependabot Quick-start Guide](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide)
 - [@official@About user alerts](https://docs.github.com/en/code-security/secret-scanning/managing-alerts-from-secret-scanning/about-alerts#about-user-alerts)
+- [@course@Git and Repository Security: Hands-on Labs](https://ransomleak.com/catalogue/git-security/)

--- a/roadmaps/git-github/content/secrets-and-env-vars@aflP7oWsQzAr4YPo2LLiQ.md
+++ b/roadmaps/git-github/content/secrets-and-env-vars@aflP7oWsQzAr4YPo2LLiQ.md
@@ -6,4 +6,5 @@ Visit the following resources to learn more:
 
 - [@official@Using secrets in GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions)
 - [@official@Store information in variables](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables)
+- [@course@CI/CD Secret Exposure: Hands-on Exercise](https://ransomleak.com/exercises/cicd-secret-exposure/)
 - [@video@Secrets and Environment Variables in your GitHub Action](https://www.youtube.com/watch?v=dPLPSaFqJmY)


### PR DESCRIPTION
Both topics currently link only to GitHub's own documentation. This adds one `@course@` link each to a browser-based exercise.

| Topic | Links before | Added |
|---|---|---|
| GitHub Security | 3 | Labs on secrets in commit history, exposed .git directories, commit author spoofing, branch-protection bypass and malicious pull requests |
| Secrets and Env Vars | 3 | Leak a secret through a workflow, find it in the run logs, then store and reference it correctly |

Disclosure: I work on RansomLeak, which hosts these exercises. They are free for individual learners with no sign-up. Same format as #10287, which was merged into the cyber-security roadmap.

https://claude.ai/code/session_01N4UCQWsmoH6URE6YjxPWgX