### PR TITLE
Add AI Product Builder Roadmap to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,7 @@ Here is the list of available roadmaps with more being actively worked upon.
 - [Data Structures and Algorithms Roadmap](https://roadmap.sh/datastructures-and-algorithms)
 - [AI and Data Scientist Roadmap](https://roadmap.sh/ai-data-scientist)
 - [AI Engineer Roadmap](https://roadmap.sh/ai-engineer)
+- [AI Product Builder Roadmap](https://roadmap.sh/ai-product-builder)
 - [Network Engineer Roadmap](https://roadmap.sh/network-engineer)
 - [AWS Roadmap](https://roadmap.sh/aws)
 - [Cloudflare Roadmap](https://roadmap.sh/cloudflare)


### PR DESCRIPTION
## Summary

Add the AI Product Builder roadmap to the list of available roadmaps in the README.

The roadmap already exists in `roadmaps/ai-product-builder` and is available at `https://roadmap.sh/ai-product-builder`, but it is currently missing from the README list.

## Changes

- Add `AI Product Builder Roadmap` to the README
- Keep the existing roadmap list structure unchanged
- No roadmap content is modified

## Verification

- Confirmed `roadmaps/ai-product-builder` exists in the repository
- Confirmed the public roadmap URL is available
- Confirmed there is no existing README entry for it
- Confirmed no competing open PR for the same README addition
- `git diff --check` passes
