### PR TITLE
Fix Google Play Services documentation link

### DIFF
--- a/roadmaps/android/content/google-play-services@m5rumeynEbS8T27pelr0-.md
+++ b/roadmaps/android/content/google-play-services@m5rumeynEbS8T27pelr0-.md
@@ -5,4 +5,4 @@ Google Play Services is a background service that provides core Google APIs to A
 Visit the following resources to learn more:
 
 - [@official@Google Play Services](https://developer.android.com/google/play-services)
-- [@official@Google Play Services Documentation](https://developer.android.com/google/play-services/overview.html)
+- [@official@Google Play Services Documentation](https://developers.google.com/android/guides/overview)


### PR DESCRIPTION
## Summary
- Replace the retired Google Play Services documentation URL with the current official overview page.

## Validation
- git diff --check
- Confirmed the replacement Google documentation URL returns HTTP 200 and identifies itself as the Overview of Google Play services.